### PR TITLE
AMBARI-26291:Set Write Permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 
+permissions:
+  contents: write
+  
 on:
   pull_request:
     branches:
@@ -12,7 +15,7 @@ jobs:
   build-website-deploy:
     runs-on: ubuntu-latest
     steps:
-      # Build main document: DolphinScheduler documentation
+      # Build main document: Apache Ambari documentation
       - name: Checkout
         uses: actions/checkout@master
 
@@ -34,3 +37,18 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: 'Automated deployment:'
+
+      - name: Update .asf.yaml
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "dev@ambari.apache.org"
+          git fetch --all
+          git checkout asf-site
+          echo 'staging:'           > .asf.yaml
+          echo '  profile: ~'       >> .asf.yaml
+          echo '  whoami: asf-site' >> .asf.yaml
+          git add .asf.yaml
+          git commit -m '.asf.yaml'
+          git push origin asf-site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated the GitHub Actions workflow file to set write permissions for GITHUB_TOKEN, enabling the workflow to perform actions requiring write access.