### PR TITLE
AMBARI-26432. DOAP file for Ambari is missing

### DIFF
--- a/static/doap.rdf
+++ b/static/doap.rdf
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         https://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://ambari.apache.org">
+    <created>2025-04-09</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Ambari</name>
+    <homepage rdf:resource="https://ambari.apache.org" />
+    <asfext:pmc rdf:resource="https://ambari.apache.org" />
+    <shortdesc>Hadoop cluster management</shortdesc>
+    <description>Apache Ambari simplifies provisioning, managing, and monitoring of Apache Hadoop clusters.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/AMBARI" />
+    <mailing-list rdf:resource="https://lists.apache.org/list.html?dev@ambari.apache.org" />
+    <download-page rdf:resource="https://ambari.apache.org/" />
+    <programming-language>Java</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <programming-language>Python</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/big-data" />
+    <release>
+      <Version>
+        <name>Apache Ambari 3.0.0</name>
+        <created>2025-04-06</created>
+        <revision>3.0.0</revision>
+      </Version>
+      <Version>
+        <name>Apache Ambari 2.7.9</name>
+        <created>2024-12-20</created>
+        <revision>2.7.9</revision>
+      </Version>
+      <Version>
+        <name>Apache Ambari 2.7.8</name>
+        <created>2024-02-01</created>
+        <revision>2.7.8</revision>
+      </Version>
+    </release>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/ambari.git"/>
+        <browse rdf:resource="https://github.com/apache/ambari"/>
+      </GitRepository>
+    </repository>
+  </Project>
+</rdf:RDF>
+


### PR DESCRIPTION
We are missing the DOAP file per Apache guideline: https://projects.apache.org/doap.html

https://projects.apache.org/project.html?ambari

This file is created using wizard https://projects.apache.org/create.html