### PR TITLE
AMBARI-26473: Mailing list link is missing

### DIFF
--- a/docs/quick-start/mailing-list.md
+++ b/docs/quick-start/mailing-list.md
@@ -1,0 +1,57 @@
+---
+title: Mailing Lists
+---
+
+# Ambari Mailing Lists
+
+Welcome to the Apache Ambari Mailing Lists page. These mailing lists are the primary communication channels for the Ambari community, where you can discuss development, ask questions, report issues, and stay updated on project activities.
+
+## Available Mailing Lists
+
+Below are the mailing lists established for the Apache Ambari project. Each list includes links to subscribe, unsubscribe, post messages, and access the archive.
+
+| Name              | Description                                                                 | Subscribe                                      | Unsubscribe                                    | Post                                         | Archive                                                       |
+|-------------------|-----------------------------------------------------------------------------|-----------------------------------------------|-----------------------------------------------|---------------------------------------------|--------------------------------------------------------------|
+| User List         | For general questions, discussions, and support related to using Ambari.     | [Subscribe](mailto:user-subscribe@ambari.apache.org) | [Unsubscribe](mailto:user-unsubscribe@ambari.apache.org) | [Post](mailto:user@ambari.apache.org)       | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-user/) |
+| Development List  | For technical discussions about Ambari development and contributions.        | [Subscribe](mailto:dev-subscribe@ambari.apache.org)  | [Unsubscribe](mailto:dev-unsubscribe@ambari.apache.org)  | [Post](mailto:dev@ambari.apache.org)        | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-dev/)  |
+| JIRA List         | For notifications and discussions about Ambari JIRA issues and tickets.      | [Subscribe](mailto:issues-subscribe@ambari.apache.org) | [Unsubscribe](mailto:issues-unsubscribe@ambari.apache.org) | [Post](mailto:issues@ambari.apache.org)       | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-issues/) |
+| Review Board List | For code review discussions and feedback on proposed changes.                | [Subscribe](mailto:reviews-subscribe@ambari.apache.org) | [Unsubscribe](mailto:reviews-unsubscribe@ambari.apache.org) | [Post](mailto:reviews@ambari.apache.org)   | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-reviews/) |
+| Commit List       | For notifications about code commits and repository updates.                 | [Subscribe](mailto:commits-subscribe@ambari.apache.org) | [Unsubscribe](mailto:commits-unsubscribe@ambari.apache.org) | [Post](mailto:commits@ambari.apache.org)   | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-commits/) |
+
+## How to Participate  
+
+1. **Choose a Mailing List**: Select the list that matches your interest (e.g., user support, development, or issue tracking).
+2. **Subscribe**: Click the "Subscribe" link and follow the instructions in the confirmation email.
+3. **Post Messages**: Once subscribed, you can send emails to the list’s posting address to start or join discussions.
+4. **Access Archives**: Browse past discussions using the archive links for reference or context.
+
+## Guidelines
+
+- Be respectful and professional in all communications.
+- Search the archives before posting to avoid duplicate questions.
+- Include relevant details (e.g., Ambari version, environment) when asking for help.
+- For bug reports or feature requests, consider using the [Ambari JIRA](https://issues.apache.org/jira/projects/AMBARI) instead of mailing lists.
+
+## Troubleshooting
+
+If you encounter issues with the mailing lists:
+
+1. **Subscription Problems**:
+   - Ensure you’ve confirmed your subscription via the email sent to you.
+   - Check your spam/junk folder for confirmation emails.
+   - Contact the list administrator (e.g., `user-help@ambari.apache.org`) for assistance.
+
+2. **Posting Issues**:
+   - Verify you’re sending emails from the subscribed email address.
+   - Ensure your message complies with the list’s guidelines to avoid moderation.
+
+3. **Archive Access**:
+   - If archive links are unavailable, try again later or contact the Apache mailing list support team.
+
+## Important Notes
+
+- Mailing lists are hosted by Apache and follow Apache Software Foundation guidelines.
+- Archives are publicly accessible, so avoid sharing sensitive information.
+- High email volume is expected on active lists like Development and JIRA; consider using digest mode for subscriptions if needed.
+
+For additional help, refer to the [FAQ](faq.md) or file an issue in the [Ambari JIRA](https://issues.apache.org/jira/projects/AMBARI).

--- a/docs/quick-start/quick-start-guide.md
+++ b/docs/quick-start/quick-start-guide.md
@@ -91,6 +91,6 @@ If you encounter any issues during setup or installation, please refer to our [*
 
 For additional help, you can:
 
-- Join the [**Ambari mailing lists**](https://web.archive.org/web/20240623133441/https://ambari.apache.org/mail-lists.html)
+- Join the [**Ambari mailing lists**](mailing-list.md)
 - File issues in the [**Ambari JIRA**](https://issues.apache.org/jira/projects/AMBARI)
 - Contribute to the [**Ambari Wiki**](https://cwiki.apache.org/confluence/display/AMBARI/Ambari)

--- a/docs/quick-start/quick-start-guide.md
+++ b/docs/quick-start/quick-start-guide.md
@@ -91,6 +91,6 @@ If you encounter any issues during setup or installation, please refer to our [*
 
 For additional help, you can:
 
-- Join the [**Ambari mailing lists**](https://ambari.apache.org/mail-lists.html)
+- Join the [**Ambari mailing lists**](https://web.archive.org/web/20240623133441/https://ambari.apache.org/mail-lists.html)
 - File issues in the [**Ambari JIRA**](https://issues.apache.org/jira/projects/AMBARI)
 - Contribute to the [**Ambari Wiki**](https://cwiki.apache.org/confluence/display/AMBARI/Ambari)

--- a/versioned_docs/version-3.0.0/quick-start/mailing-list.md
+++ b/versioned_docs/version-3.0.0/quick-start/mailing-list.md
@@ -1,0 +1,57 @@
+---
+title: Mailing Lists
+---
+
+# Ambari Mailing Lists
+
+Welcome to the Apache Ambari Mailing Lists page. These mailing lists are the primary communication channels for the Ambari community, where you can discuss development, ask questions, report issues, and stay updated on project activities.
+
+## Available Mailing Lists
+
+Below are the mailing lists established for the Apache Ambari project. Each list includes links to subscribe, unsubscribe, post messages, and access the archive.
+
+| Name              | Description                                                                 | Subscribe                                      | Unsubscribe                                    | Post                                         | Archive                                                       |
+|-------------------|-----------------------------------------------------------------------------|-----------------------------------------------|-----------------------------------------------|---------------------------------------------|--------------------------------------------------------------|
+| User List         | For general questions, discussions, and support related to using Ambari.     | [Subscribe](mailto:user-subscribe@ambari.apache.org) | [Unsubscribe](mailto:user-unsubscribe@ambari.apache.org) | [Post](mailto:user@ambari.apache.org)       | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-user/) |
+| Development List  | For technical discussions about Ambari development and contributions.        | [Subscribe](mailto:dev-subscribe@ambari.apache.org)  | [Unsubscribe](mailto:dev-unsubscribe@ambari.apache.org)  | [Post](mailto:dev@ambari.apache.org)        | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-dev/)  |
+| JIRA List         | For notifications and discussions about Ambari JIRA issues and tickets.      | [Subscribe](mailto:issues-subscribe@ambari.apache.org) | [Unsubscribe](mailto:issues-unsubscribe@ambari.apache.org) | [Post](mailto:issues@ambari.apache.org)       | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-issues/) |
+| Review Board List | For code review discussions and feedback on proposed changes.                | [Subscribe](mailto:reviews-subscribe@ambari.apache.org) | [Unsubscribe](mailto:reviews-unsubscribe@ambari.apache.org) | [Post](mailto:reviews@ambari.apache.org)   | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-reviews/) |
+| Commit List       | For notifications about code commits and repository updates.                 | [Subscribe](mailto:commits-subscribe@ambari.apache.org) | [Unsubscribe](mailto:commits-unsubscribe@ambari.apache.org) | [Post](mailto:commits@ambari.apache.org)   | [View Archive](https://mail-archives.apache.org/mod_mbox/ambari-commits/) |
+
+## How to Participate  
+
+1. **Choose a Mailing List**: Select the list that matches your interest (e.g., user support, development, or issue tracking).
+2. **Subscribe**: Click the "Subscribe" link and follow the instructions in the confirmation email.
+3. **Post Messages**: Once subscribed, you can send emails to the list’s posting address to start or join discussions.
+4. **Access Archives**: Browse past discussions using the archive links for reference or context.
+
+## Guidelines
+
+- Be respectful and professional in all communications.
+- Search the archives before posting to avoid duplicate questions.
+- Include relevant details (e.g., Ambari version, environment) when asking for help.
+- For bug reports or feature requests, consider using the [Ambari JIRA](https://issues.apache.org/jira/projects/AMBARI) instead of mailing lists.
+
+## Troubleshooting
+
+If you encounter issues with the mailing lists:
+
+1. **Subscription Problems**:
+   - Ensure you’ve confirmed your subscription via the email sent to you.
+   - Check your spam/junk folder for confirmation emails.
+   - Contact the list administrator (e.g., `user-help@ambari.apache.org`) for assistance.
+
+2. **Posting Issues**:
+   - Verify you’re sending emails from the subscribed email address.
+   - Ensure your message complies with the list’s guidelines to avoid moderation.
+
+3. **Archive Access**:
+   - If archive links are unavailable, try again later or contact the Apache mailing list support team.
+
+## Important Notes
+
+- Mailing lists are hosted by Apache and follow Apache Software Foundation guidelines.
+- Archives are publicly accessible, so avoid sharing sensitive information.
+- High email volume is expected on active lists like Development and JIRA; consider using digest mode for subscriptions if needed.
+
+For additional help, refer to the [FAQ](faq.md) or file an issue in the [Ambari JIRA](https://issues.apache.org/jira/projects/AMBARI).

--- a/versioned_docs/version-3.0.0/quick-start/quick-start-guide.md
+++ b/versioned_docs/version-3.0.0/quick-start/quick-start-guide.md
@@ -91,6 +91,6 @@ If you encounter any issues during setup or installation, please refer to our [*
 
 For additional help, you can:
 
-- Join the [**Ambari mailing lists**](https://ambari.apache.org/mail-lists.html)
+- Join the [**Ambari mailing lists**](https://web.archive.org/web/20240623133441/https://ambari.apache.org/mail-lists.html)
 - File issues in the [**Ambari JIRA**](https://issues.apache.org/jira/projects/AMBARI)
 - Contribute to the [**Ambari Wiki**](https://cwiki.apache.org/confluence/display/AMBARI/Ambari)

--- a/versioned_docs/version-3.0.0/quick-start/quick-start-guide.md
+++ b/versioned_docs/version-3.0.0/quick-start/quick-start-guide.md
@@ -91,6 +91,6 @@ If you encounter any issues during setup or installation, please refer to our [*
 
 For additional help, you can:
 
-- Join the [**Ambari mailing lists**](https://web.archive.org/web/20240623133441/https://ambari.apache.org/mail-lists.html)
+- Join the [**Ambari mailing lists**](mailing-list)
 - File issues in the [**Ambari JIRA**](https://issues.apache.org/jira/projects/AMBARI)
 - Contribute to the [**Ambari Wiki**](https://cwiki.apache.org/confluence/display/AMBARI/Ambari)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Join the [Ambari mailing lists](https://ambari.apache.org/mail-lists.html) --> the link is gone.
### How was this patch tested?
yarn srart
