### PR TITLE
AMBARI-26433:Website: Add required links and contents per Apache policy

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,18 +122,41 @@ const config = {
             position: 'left',
             label: 'Project Information',
             items: [
-              {
-                label: 'Apache Software Foundation',
-                href: 'https://www.apache.org/',
+              /* Temporarily commented out because these two documents are too large and depend on the Ambari project generation.
+                 They cannot be treated as static files pushed to git, and they also block the GitHub workflow process.
+             {
+                label: 'Old Version Website',
+                target: '_blank',
+                to: '/old/',
               },
               {
-                label: 'ApacheCon Events',
-                href: 'https://www.apachecon.com/',
+                label: 'Swagger API Doc',
+                target: '_blank',
+                to: '/swagger/',
               },
               {
-                label: 'Mailing List',
-                href: 'mailto:dev@ambari.apache.org',
+                label: 'Java Doc',
+                target: '_blank',
+                to: '/javadoc/apidocs',
+              },*/
+              {
+                label: 'Project Team',
+                target: '_blank',
+                to: '/team',
               },
+              {
+                label: 'JIRA',
+                href: 'https://issues.apache.org/jira/projects/AMBARI/issues',
+              },
+              {
+                label: 'User Group',
+                href: 'https://www.meetup.com/Apache-Ambari-User-Group/',
+              },
+ /*             {
+                label: 'Maling List',
+                target: '_blank',
+                to: '/old/mail-lists.html',
+              },*/
             ],
           },
           {
@@ -145,6 +168,14 @@ const config = {
               {
                 label: 'License',
                 href: 'https://www.apache.org/licenses/',
+              },
+              {
+                label: 'Apache Software Foundation',
+                href: 'https://www.apache.org/',
+              },
+              {
+                label: 'ApacheCon Events',
+                href: 'https://www.apachecon.com/',
               },
               {
                 label: 'Privacy Policy',
@@ -171,9 +202,19 @@ const config = {
         ],
       },
       footer: {
-        copyright: `Copyright 2025 Apache Ambari. Built with Docusaurus.<br/>Apache Ambari and the Apache Ambari logo are trademarks of The Apache Software Foundation.`,
+        style: 'dark',
+        copyright: `Copyright ${new Date().getFullYear()} Apache Ambari. Built with Docusaurus.`,
+      },
+      prism: {
+        theme: themes.github,
+        darkTheme: themes.dracula,
+        additionalLanguages: ['bash', 'diff', 'json'],
       }
     }),
-};
+    plugins: [
+      'docusaurus-plugin-less',
+      require.resolve('./src/plugins/csp-plugin'),
+    ],
+  };
 
-module.exports = config;
+export default config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,72 +122,58 @@ const config = {
             position: 'left',
             label: 'Project Information',
             items: [
-            /* Temporarily commented out because these two documents are too large and depend on the Ambari project generation.
-                 They cannot be treated as static files pushed to git, and they also block the GitHub workflow process.
-             {
-                label: 'Old Version Website',
-                target: '_blank',
-                to: '/old/',
+              {
+                label: 'Apache Software Foundation',
+                href: 'https://www.apache.org/',
               },
               {
-                label: 'Swagger API Doc',
-                target: '_blank',
-                to: '/swagger/',
+                label: 'ApacheCon Events',
+                href: 'https://www.apachecon.com/',
               },
               {
-                label: 'Java Doc',
-                target: '_blank',
-                to: '/javadoc/apidocs',
-              },*/
-              {
-                label: 'Project Team',
-                target: '_blank',
-                to: '/team',
+                label: 'Mailing List',
+                href: 'mailto:dev@ambari.apache.org',
               },
-              {
-                label: 'JIRA',
-                href: 'https://issues.apache.org/jira/projects/AMBARI/issues',
-              },
-              {
-                label: 'User Group',
-                href: 'https://www.meetup.com/Apache-Ambari-User-Group/',
-              },
- /*             {
-                label: 'Maling List',
-                target: '_blank',
-                to: '/old/mail-lists.html',
-              },*/
-              {
-                label: "Project License",
-                href: 'https://www.apache.org/licenses/'
-              }
             ],
           },
           {
-            type: 'docsVersionDropdown',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/apache/ambari',
-            label: 'GitHub',
-            position: 'right',
+            title: 'Legal',
+            type: 'dropdown',
+            position: 'left',
+            label: 'Apache',
+            items: [
+              {
+                label: 'License',
+                href: 'https://www.apache.org/licenses/',
+              },
+              {
+                label: 'Privacy Policy',
+                href: 'https://privacy.apache.org/policies/privacy-policy-public.html',
+              },
+              {
+                label: 'Security',
+                href: 'https://www.apache.org/security/',
+              },
+              {
+                label: 'Trademarks',
+                href: 'https://www.apache.org/foundation/marks/',
+              },
+              {
+                label: 'Sponsorship',
+                href: 'https://www.apache.org/foundation/sponsorship.html',
+              },
+              {
+                label: 'Thanks our Sponsors',
+                href: 'https://www.apache.org/foundation/thanks.html',
+              },
+            ],
           },
         ],
       },
       footer: {
-        style: 'dark',
-        copyright: `Copyright ${new Date().getFullYear()} Apache Ambari. Built with Docusaurus.`,
-      },
-      prism: {
-        theme: themes.github,
-        darkTheme: themes.dracula,
-        additionalLanguages: ['bash', 'diff', 'json'],
-      },
+        copyright: `Copyright 2025 Apache Ambari. Built with Docusaurus.<br/>Apache Ambari and the Apache Ambari logo are trademarks of The Apache Software Foundation.`,
+      }
     }),
-  plugins: [
-    'docusaurus-plugin-less',
-    require.resolve('./src/plugins/csp-plugin'),
-  ],
 };
 
-export default config;
+module.exports = config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -160,6 +160,15 @@ const config = {
             ],
           },
           {
+            type: 'docsVersionDropdown',
+            position: 'right',
+          },
+          {
+            href: 'https://github.com/apache/ambari',
+            label: 'GitHub',
+            position: 'right',
+          },
+          {
             title: 'Legal',
             type: 'dropdown',
             position: 'left',

--- a/sidebars.js
+++ b/sidebars.js
@@ -188,7 +188,55 @@ const sidebars = {
         "ambari-plugin-contribution/step-by-step"
       ]
     },
-    "ambari-alerts"
+    "ambari-alerts",
+    {
+      "type": "category",
+      "label": "Apache",
+      "collapsible": true,
+      "collapsed": false,
+      "items": [
+        {
+          "type": "link",
+          "label": "Foundation",
+          "href": "https://www.apache.org/"
+        },
+        {
+          "type": "link",
+          "label": "Events",
+          "href": "https://www.apachecon.com/"
+        },
+        {
+          "type": "link",
+          "label": "License",
+          "href": "https://www.apache.org/licenses/"
+        },
+        {
+          "type": "link",
+          "label": "Thanks",
+          "href": "https://www.apache.org/foundation/thanks.html"
+        },
+        {
+          "type": "link",
+          "label": "Security",
+          "href": "https://www.apache.org/security/" // if we have specific security.html, it should be here
+        },
+        {
+          "type": "link",
+          "label": "Sponsorship",
+          "href": "https://www.apache.org/foundation/sponsorship.html"
+        },
+        {
+          "type": "link",
+          "label": "Trademarks",
+          "href": "https://www.apache.org/foundation/marks/"
+        },
+        {
+          "type": "link",
+          "label": "Privacy",
+          "href": "https://privacy.apache.org/policies/privacy-policy-public.html"
+        },
+      ]
+    }
   ]
 };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Added missing links in the sidebar:
Created a new "Apache" category in the sidebar (sidebars.js) to include all required ASF links:
Foundation: https://www.apache.org/
Events: https://www.apachecon.com/
License: https://www.apache.org/licenses/
Thanks: https://www.apache.org/foundation/thanks.html
Security: https://www.apache.org/security/ (or project-specific /security if applicable)
Sponsorship: https://www.apache.org/foundation/sponsorship.html
Trademarks: https://www.apache.org/foundation/marks/
Privacy: https://privacy.apache.org/policies/privacy-policy-public.html
Removed the invalid project-license reference from the sidebar, as it was redundant with the "License" link and caused a Docusaurus error due to a missing document.

## How was this patch tested?
Run yarn start to start the Docusaurus development server locally.
Checked the sidebar to confirm the new "Apache" category appears and contains all required links.