### PR TITLE
AMBARI-26490: Website: Update Building Ambari Metrics

### DIFF
--- a/docs/ambari-dev/building-from-source.md
+++ b/docs/ambari-dev/building-from-source.md
@@ -19,6 +19,9 @@ Before you begin, ensure you have the following requirements installed:
 - Ambari Metrics: JDK 8
 - Ambari Infra: JDK 8
 
+### Additional Packages
+- snappy-devel
+
 ## Building Ambari Main Project
 
 ### 1. Clone the Repository

--- a/docs/ambari-dev/running-tests.md
+++ b/docs/ambari-dev/running-tests.md
@@ -107,3 +107,35 @@ Test reports can be found in the following locations after test execution:
 :::tip
 When debugging test failures, check these report directories for detailed test execution logs and stack traces.
 :::
+
+# Running Tests in Apache Ambari Metrics
+
+### 1. Install Prequisites
+Ambari Metrics requires a few more prerequisite for unit testing.
+
+```bash
+yum install -y krb5-devel
+pip3 install distro kerberos
+```
+
+## Java Tests
+
+### Running All Java Tests
+To run all Java tests for the Ambari Metrics:
+```bash
+mvn test \
+    -DskipPythonTests \
+    -Dmaven.test.failure.ignore \
+    -Dmaven.artifact.threads=10 \
+    -Drat.skip
+```
+
+## All Tests (Python and Java)
+
+To run all Java tests for the Ambari Metrics:
+```bash
+mvn test \
+    -Dmaven.test.failure.ignore \
+    -Dmaven.artifact.threads=10 \
+    -Drat.skip
+```


### PR DESCRIPTION
1. Ambari installation requires snappy-devel.
2. Test command and prerequisite for Ambari Metrics.